### PR TITLE
Fix: Typos

### DIFF
--- a/apps/docs/pages/architecture/conditions.md
+++ b/apps/docs/pages/architecture/conditions.md
@@ -12,10 +12,10 @@ type Condition = {
 ```
 
 ### ID
-Unique identifier using the a URN pattern (e.x. condition:identification:property).
+Unique identifier using the URN pattern (e.x. condition:identification:property).
 
 ### Entity ID (eid)
-Target entity id to run condition condition operations on.
+Target entity id to run condition operations on.
 
 ### Operations
 Logic branch operations for conditions and other rules.
@@ -62,11 +62,11 @@ A smart contract entity might have multiple methods which can be executed.
 }
 ```
 
-In the above example we've applied a condition to the `PT:V4:PrizePool:0x79bc8bd53244bc8a9c8c27509a2d573650a83373:Optimism` entity which measures a specific transaction EVM state artifact.
+In the above example, we've applied a condition to the `PT:V4:PrizePool:0x79bc8bd53244bc8a9c8c27509a2d573650a83373:Optimism` entity which measures a specific transaction EVM state artifact.
 
-The condition specifically states a `Transaction` EVM state artifact, denoted by the `"type": "transaction"` field, calling the target entity must include the a deposit amount greater than 10 USDC.
+The condition specifically states a `Transaction` EVM state artifact, denoted by the `"type": "transaction"` field, calling the target entity must include a deposit amount greater than 10 USDC.
 
-Multiple conditions can be applied to the same entity. For example you could require both `depositTo` and `withdraw` transactions artifacts to be present before the set can be validated. In that instance it would require both the `depositTo` and `withdraw` transaction EVM state artifacts to be passed into the runtime engine.
+Multiple conditions can be applied to the same entity. For example, you could require both `depositTo` and `withdraw` transaction artifacts to be present before the set can be validated. In that instance, it would require both the `depositTo` and `withdraw` transaction EVM state artifacts to be passed into the runtime engine.
 
 For brevities sake let's example the `credential` Entity will conditions applied to state artifacts.
 
@@ -93,7 +93,7 @@ For brevities sake let's example the `credential` Entity will conditions applied
 				},
 				{
 					"method": "observe",
-					"args": ["credentialSubject.membershipLevel", ">=", "5"]
+					"args": ["credentialSubject.membershipLevel", "gte", "5"]
 				}
 			]
 		}

--- a/apps/docs/pages/architecture/entities.md
+++ b/apps/docs/pages/architecture/entities.md
@@ -10,7 +10,7 @@ type Entity = {
 ```
 
 ### ID
-Unique identifier using the a URN pattern (e.x. entity:[protocol]:[version])
+Unique identifier using the URN pattern (e.x. entity:[protocol]:[version])
 
 ## How It Works
 
@@ -21,7 +21,7 @@ Resource objects like smart contracts, verifiable credentials, decentralized ide
  - decentralized identifiers 
  - public key registries
 
-In Web3 Sets each Entity is measured according to it's unique properties.
+In Web3 Sets each Entity is measured according to its unique properties.
 
 Below are examples of a smart contract and verifiable credentials entities.
 
@@ -52,7 +52,7 @@ Below are examples of a smart contract and verifiable credentials entities.
 
 As you can see each `Entity` has unique identifying properties. The properties are used to "hydrate" the entity during runtime execution.
 
-In the case of the smart contract entity hydration is characterized by fetching the ABI reference. For other entities like verifiable credential it requires triggering a selective disclosure request and obtaining credentials that will be presumed to pass validation during the runtime.
+In the case of the smart contract entity hydration is characterized by fetching the ABI reference. For other entities like verifiable credential, it requires triggering a selective disclosure request and obtaining credentials that will be presumed to pass validation during the runtime.
 
 If the Entity can be defined (measurable inputs and outputs) it can be added to a Web3 Sets schema and runtime.
 

--- a/apps/docs/pages/architecture/operations.md
+++ b/apps/docs/pages/architecture/operations.md
@@ -4,7 +4,7 @@ Conditions and Rules both contain operations.
 
 Operations are operators applied to entity artifacts and logic branching.
 
-They condition and rule operations are responsible for "constraining" what state you care about and describing desired state positions.
+The condition and rule operations are responsible for "constraining" what state you care about and describing desired state positions.
 
 ## EVM
 

--- a/apps/docs/pages/architecture/rules.md
+++ b/apps/docs/pages/architecture/rules.md
@@ -12,12 +12,12 @@ type Rule = {
 ```
 
 ### ID
-Unique identifier using the a URN pattern (e.x. rule:identification:property)
+Unique identifier using the URN pattern (e.x. rule:identification:property)
 
 ### Root
 The `root` boolean field designates an entry rule. **A set must have 1 or more root rules.**
 
-For example if 3 rules exist, but 1 of those rules is `oneOf` for the 2 other rules, the runtime needs to start at the root rule.
+For example, if 3 rules exist, but 1 of those rules is `oneOf` for the 2 other rules, the runtime needs to start at the root rule.
 
 The [Disco District Party Set]() set demonstrates this specific use case.
 
@@ -64,11 +64,11 @@ Logic branch operations for conditions and other rules
 }
 ```
 
-In the example above the Rule contains a `count` operation, which requires a minimum of number of the GMCredential to be available during runtime validation.
+In the example above the Rule contains a `count` operation, which requires a minimum number of the GMCredential to be available during runtime validation.
 
 Rules can also enforce logic branches on other Rules.
 
-Below is a relatively complex set defines several conditions and rules for an imagining District Disco Party. Stating that either a Membership and Ticket credential or VIP credential must be available during the runtime to pass validation.
+Below is a relatively complex set that defines several conditions and rules for an imagined District Disco Party. Stating that either a Membership and Ticket credential or VIP credential must be available during the runtime to pass validation.
 
 Simplified set statement `Membership + Ticket || Verified Identity Pass = True`
 

--- a/apps/docs/pages/architecture/state-artifacts.md
+++ b/apps/docs/pages/architecture/state-artifacts.md
@@ -2,7 +2,7 @@
 
 In Web3 Sets `artifacts` are measurable outputs of cryptographic operations.
 
-Blockchain transactions and verifiable credential issuance are examples artifacts produced by an entity.
+Blockchain transactions and verifiable credential issuance are examples of artifacts produced by an entity.
 
 For example when an Account interacts with a Smart Contract multiple EVM state artifacts can be produced: transactions, logs and storage proofs. Artifacts are cryptographically verifiable and can provide data authenticity guarantees to runtime engines.
 
@@ -23,10 +23,10 @@ State artifacts are **required** to validate sets.
 
 The **runtime** engines consume both **sets** and **state artifacts**.
 
-Without state artifacts it wouldn't be possible to check if the set condition and rule operation are satisfied, because there would be nothing to compare them against.
+Without state artifacts, it wouldn't be possible to check if the set condition and rule operation are satisfied because there would be nothing to compare them against.
 
 **How state artifacts are gathered is up to a runtime service operator.**
 
-In the case of public blockchains and rollups like Ethereum, Optimism, Arbitrum, state artifacts are relatively easy to obtain. You can request them from JSON-RPC node providers, if you trust them, or run a node and query blockchain history directly. You could even generate your own storage proofs or request storage proofs from third-party service providers.
+In the case of public blockchains and rollups like Ethereum, Optimism and Arbitrum, state artifacts are relatively easy to obtain. You can request them from JSON-RPC node providers, if you trust them, or run a node and query blockchain history directly. You could even generate your own storage proofs or request storage proofs from third-party service providers.
 
-And in some instances where data is private by default, like verifiable credentials and verifiable presentations, the state artifacts requires explicit selective disclosure requests from users.
+And in some instances where data is private by default, like verifiable credentials and verifiable presentations, the state artifacts require explicit selective disclosure requests from users.

--- a/apps/docs/pages/index.md
+++ b/apps/docs/pages/index.md
@@ -14,16 +14,16 @@ Several open source runtime engines are being developed to validate EVM and Iden
 
 ## Connecting the Dots
 
-The Web3 Universe is a decentralized, distributed and emergent. But it is a place where Entities interact with other Entities in predictable ways. Measurable and quantifiable events.
+The Web3 Universe is decentralized, distributed and emergent. But it is a place where Entities interact with other Entities in predictable ways. Measurable and quantifiable events.
 
 But we're lacking a framework to build and scale user experiences in this emergent universe. We need a way to organize and connect data in a way that is easy to understand and use.
 
 ## Approach
-Web3 Sets is light-weight and flexible. Taking a simple approach to a complex problem.
+Web3 Sets are light-weight and flexible. Taking a simple approach to a complex problem.
 
 Web3 Sets are instructions for verifying the cryptographic inputs and outputs of Web3 primitives.
 
-**The approach is simple.** Everything is Entity. Entities have predictable behaviors. Entities can be grouped into Sets. Sets can describe all past, present and future state positions, in a Web3 universe with finite entities.
+**The approach is simple.** Everything is an Entity. Entities have predictable behaviors. Entities can be grouped into Sets. Sets can describe all past, present and future state positions, in a Web3 universe with finite entities.
 
 **Web3 Sets draws inspiration from naive set theory.**
 
@@ -35,4 +35,4 @@ Web3 Sets schemas are exclusively focused on mapping Web3 primitives with predic
 
 **Web3 Sets does not care about underlying technology or implementation details.**
 
-Web3 Sets only cares about cryptographically verifiable inputs and outputs i.e. measurable state positions.
+Web3 Sets only care about cryptographically verifiable inputs and outputs i.e. measurable state positions.

--- a/apps/docs/pages/overview/use-cases.md
+++ b/apps/docs/pages/overview/use-cases.md
@@ -2,7 +2,7 @@
 
 The use case for Web3 Sets is broad. And that's because a rules engine for the Web3 universe is applicable to a variety of products.
 
-Web3 Set runtimes can be used stand-alone with other runtimes. For example the EVM Web3 Set schema can be used to power a transaction recommendation engine.
+Web3 Set runtimes can be used stand-alone with other runtimes. For example, the EVM Web3 Set schema can be used to power a transaction recommendation engine.
 Or it can be used in combination with the Identity Web3 Set runtime to build a multi-environment access control gateway.
 
 A low-level rules engine for Web3 primitives has multiple use cases.

--- a/apps/docs/pages/runtime/evm/inputs.md
+++ b/apps/docs/pages/runtime/evm/inputs.md
@@ -29,7 +29,7 @@ The `Client` and `RuntimeArguments` are only required if the Set expects the run
 
 **Basic Runtime Example**
 
-The minimum arguments required to execute the runtime is a set and state artifacts.
+The minimum arguments required to execute the runtime are a set and state artifacts.
 ```rust
 runtime({
     set, 
@@ -40,7 +40,7 @@ runtime({
 **Advanced Runtime Example**
 For sets that require `reads` and `archive_read` functionality a JSON-RPC provider client is required.
 
-If a set has dynamic arguments the runtime will also require the arguments are passed during the runtime.
+If a set has dynamic arguments the runtime will also require the arguments to be passed during the runtime.
 
 ```rust
 runtime({
@@ -118,17 +118,17 @@ runtime({
 
 ### Clients (Optional)
 
-For a Javascript runtime we recommend using the [viem](https://viem.sh/) client interface.
+For a Javascript runtime, we recommend using the [viem](https://viem.sh/) client interface.
 
-For a Rust runtime we don't recommend a specific crate. Dealers choice.
+For a Rust runtime, we don't recommend a specific crate. Dealers choice.
 
 
 ### Arguments (Optional)
 Arguments can be used to provide operation and observation inputs during runtime.
 
-For example we might have a condition that is intended to measure "burning" a token. In most cases we could hard code the `0x0` address, but there might times when a custom address is desired and we don't want to create a new set.
+For example, we might have a condition that is intended to measure "burning" a token. In most cases, we could hard code the `0x0` address, but there might be times when a custom address is desired and we don't want to create a new set.
 
-For these instances we can use arguments to hydrate set condition and rule operation arguments, before comparing the set to state artifacts.
+For these instances, we can use arguments to hydrate set condition and rule operation arguments, before comparing the set to state artifacts.
 
 ```js
 // runtime arguments

--- a/apps/docs/pages/runtime/evm/mutations.md
+++ b/apps/docs/pages/runtime/evm/mutations.md
@@ -3,7 +3,7 @@
 ## Hydration
 Before the set is compared to state artifacts it first undergoes hydration.
 
-Entity hydration is required for fetching external interface, like smart contract application binary interfaces and verifiable credential schemas.
+Entity hydration is required for fetching external interfaces, like smart contract application binary interfaces and verifiable credential schemas.
 
 ```ts
 export const EVMSetHydrated = {
@@ -282,4 +282,4 @@ After the artifacts have been added to the new Entity object being hydrated, raw
 }
 ```
 
-Once hydration occurs, and state artifacts parsed, condition and rules operations can be applied.
+Once hydration occurs, and state artifacts are parsed, condition and rules operations can be applied.

--- a/apps/docs/pages/schemas/evm/artifacts.md
+++ b/apps/docs/pages/schemas/evm/artifacts.md
@@ -90,7 +90,7 @@ And here is an example of a condition that will correctly identify the state art
 ],
 ```
 
-During runtime the data field will be decoded and compared with the operation.
+During runtime, the data field will be decoded and compared with the operation.
 
 **Raw inputs**
 ```rust
@@ -124,4 +124,4 @@ As we can see the observe operation condition has been met.
 [1]:  42000000
 ```
 
-Since `42000000` is greater than or equal to `10000000` the operation conditional has been satisfed.
+Since `42000000` is greater than or equal to `10000000` the operation conditional has been satisfied.

--- a/apps/docs/pages/schemas/evm/conditions.md
+++ b/apps/docs/pages/schemas/evm/conditions.md
@@ -27,10 +27,10 @@ type Condition = {
 - observeOneOf([(key:String, operator: Operator, value: String | Number)])
 
 ### ID
-Unique identifier using the a URN pattern (e.x. condition:identification:property).
+Unique identifier using the URN pattern (e.x. condition:identification:property).
 
 ### Entity ID (eid)
-Target entity id to run condition condition operations on.
+Target entity id to run condition operations on.
 
 ### Operations
 Logic branch operations for conditions and other rules.
@@ -166,7 +166,7 @@ Example of observation of transaction input values with deeply nested values ins
             "observations": [
             {
                 "index": 0,
-                "condition": "==",
+                "condition": "eq",
                 "selector": "[0].invocations.batch[0].authority[0].delegation.caveats[0].terms",
                 "value": "0x0000000000000000000000000000000000000000000000000000000000000001"
             }
@@ -179,4 +179,4 @@ In the snippet above we reference a NFT smart contract that inherits the [delega
 
 A single condition operator states it wants to "observe" when a user executes the `invoke` function with a deeply nested value inside of an object, inside of a tuple.
 
-The value we're searching for `0x0000...00001` inside of the `terms` field describes specific permissions assigned to a user before transaction execution. The purpose of this example is to demonstrate we can observe very specific slice of data in a [state artifact](/architecture/state-artifacts.md). 
+The value we're searching for `0x0000...00001` inside of the `terms` field describes specific permissions assigned to a user before transaction execution. The purpose of this example is to demonstrate we can observe a very specific slice of data in a [state artifact](/architecture/state-artifacts.md). 

--- a/apps/docs/pages/schemas/evm/entities.md
+++ b/apps/docs/pages/schemas/evm/entities.md
@@ -27,7 +27,7 @@ A `SmartContract` entity requires the `chainId`, `address` and `abi` fields.
 
 These fields are used to identify, locate and initialize a [state artifact](/architecture/state-artifacts) interpreter.
 
-Below is an an example of PoolTogether V4 PrizePool on the Optimism rollup. 
+Below is an example of PoolTogether V4 PrizePool on the Optimism rollup. 
 
 ```json
 // Smart Contracts

--- a/apps/docs/pages/schemas/evm/rules.md
+++ b/apps/docs/pages/schemas/evm/rules.md
@@ -2,7 +2,7 @@
 
 Rules are logic branches applied to Conditions and other Rules.
 
-- id - unique identifier using the a URN pattern (e.x. rule:identification:property)
+- id - unique identifier using the URN pattern (e.x. rule:identification:property)
 - root - status flag if the rule operation is an entry rule
 - operations - logic branches for conditions and other rules
 
@@ -80,7 +80,7 @@ In the example below the `all` rule operation is applied to the singular conditi
 
 Can you guess what will happen during runtime?
 
-The `all` operation checks if all of the `condition` is reference is satisfied.
+The `all` operation checks if all of the `condition` reference is satisfied.
 
 The `all` operator accepts a list condition or rule references, but since this set only contains a single condition and a single rule, we only pass in the single condition with the identifier `condition:depositTo`.
 

--- a/apps/docs/pages/schemas/identity/artifacts.md
+++ b/apps/docs/pages/schemas/identity/artifacts.md
@@ -83,7 +83,7 @@ Coming soon...
 
 ### Verifiable Credential
 
-Below is an an example of a verifiable credential artifact of type GMCredential.
+Below is an example of a verifiable credential artifact of type GMCredential.
 
 The `VerifiableCredential` artifact even includes a reference `DataSchema` entity in the `credentialSchema.id` field.
 

--- a/apps/docs/pages/schemas/identity/conditions.md
+++ b/apps/docs/pages/schemas/identity/conditions.md
@@ -12,10 +12,10 @@ type Condition = {
 ```
 
 ### ID
-Unique identifier using the a URN pattern (e.x. condition:identification:property).
+Unique identifier using the URN pattern (e.x. condition:identification:property).
 
 ### Entity ID (eid)
-Target entity id to run condition condition operations on.
+Target entity id to run condition operations on.
 
 ### Operations
 Logic branch operations for conditions and other rules.
@@ -50,7 +50,7 @@ type Condition = {
 ## How It Works
 A verifiable credential artifact matching the entity schema must be presented.
 
-In the `MembershipCredential` credential, a membershipLevel field is a child of the `credentialSubject` field.
+In the `MembershipCredential` credential, a `membershipLevel` field is a child of the `credentialSubject` field.
 
 ```json
 {
@@ -74,7 +74,7 @@ In the `MembershipCredential` credential, a membershipLevel field is a child of 
 				},
 				{
 					"method": "observe",
-					"args": ["credentialSubject.membershipLevel", ">=", "5"]
+					"args": ["credentialSubject.membershipLevel", "gte", "5"]
 				}
 			]
 		}

--- a/apps/docs/pages/schemas/identity/entities.md
+++ b/apps/docs/pages/schemas/identity/entities.md
@@ -1,6 +1,6 @@
 # Entities
 
-The Identity set contains a two primary entity types.
+The Identity set contains two primary entity types.
 
 **Types**
 - Data Schema (schema)
@@ -13,7 +13,7 @@ type DataSchema {
 ```
 
 ### ID
-Unique identifier using the a URN pattern (e.x. entity:identification:property).
+Unique identifier using the URN pattern (e.x. entity:identification:property).
 
 ### Schema
 Reference to a schema for generating a verifiable credential state artifact.
@@ -22,7 +22,7 @@ Reference to a schema for generating a verifiable credential state artifact.
 
 A `DataSchema` Entity describes how a `VerifiableCredential` artifact will be generated.
 
-For example the entity below contains a reference to the `GMCredential` credential schema.
+For example, the entity below contains a reference to the `GMCredential` credential schema.
 
 ```json
 "entities": [
@@ -62,8 +62,8 @@ A GMCredential state artifact (i.e. verifiable credential) will resemble the exa
 }
 ```
 
-For simplicity sake thing of Entities as describing how Artifacts will be generated. Artifacts are the objects, which contain data we can cryptographically prove.
+For simplicity's sake think of Entities as describing how Artifacts will be generated. Artifacts are the objects, which contain data we can cryptographically prove.
 
-In this instance, we know we want a verifiable credential of type GMCredential, so we reference the Entity (DataSchema), which gives us the metedata we need to accurately validate the GMCredential at runtime.
+In this instance, we know we want a verifiable credential of type GMCredential, so we reference the Entity (DataSchema), which gives us the metadata we need to accurately validate the GMCredential at runtime.
 
-Since the GMCredential only contains an `id` key in the `credentialSubject` it's relatively simple to parse. But more complex verifiable credentials require more complex validation condition and rules, depending on the type of data being requested.
+Since the GMCredential only contains an `id` key in the `credentialSubject` it's relatively simple to parse. But more complex verifiable credentials require more complex validation conditions and rules, depending on the type of data being requested.

--- a/apps/docs/pages/schemas/identity/rules.md
+++ b/apps/docs/pages/schemas/identity/rules.md
@@ -2,7 +2,7 @@
 
 Rules are logic branches applied to Conditions and other Rules.
 
-- id - unique identifier using the a URN pattern (e.x. rule:identification:property)
+- id - unique identifier using the URN pattern (e.x. rule:identification:property)
 - root - status flag if the rule operation is an entry rule
 - operations - logic branches for conditions and other rules
 
@@ -64,7 +64,7 @@ In the example below the `all` rule operation is applied to the singular conditi
             },
             {
                 "method": "observe",
-                "args": ["credentialSubject.membershipLevel", ">=", "5"]
+                "args": ["credentialSubject.membershipLevel", "gte", "5"]
             }
         ]
     }
@@ -85,15 +85,15 @@ In the example below the `all` rule operation is applied to the singular conditi
 
 Can you guess what will happen during runtime?
 
-The `all` operation checks if all of the `condition` is reference is satisfied. In this case we're checking to see if the `membershipLevel` field has a value greater than 5.
+The `all` operation checks if all of the `condition` is reference is satisfied. In this case, we're checking to see if the `membershipLevel` field has a value greater than 5.
 
 The `all` operator accepts a list condition or rule references, but since this set only contains a single condition and a single rule, we only pass in the single condition with the identifier `condition:membership:issuance`.
 
 ## Rule Recursion
 
-Rules can also reference other rules. Which is why a set must contain at-least 1 rule with `root` set to `true`, because the runtime engine needs to know which rule(s) to start traversing operations from.
+Rules can also reference other rules. This is why a set must contain at least 1 rule with `root` set to `true`, because the runtime engine needs to know which rule(s) to start traversing operations from.
 
-Below is an example of set the describes requiring presenting a Membership/Ticket or a Verified Identity Pass. A set like this is useful for programmatically requesting a verifiable presentation from a user at an event. If either condition is met, than the guest can enter the event. And if no conditions are met it means they were not invited.
+Below is an example of set that describes requiring presenting a Membership/Ticket or a Verified Identity Pass. A set like this is useful for programmatically requesting a verifiable presentation from a user at an event. If either condition is met, then the guest can enter the event. And if no conditions are met it means they were not invited.
 
 ```json
 "entities": [
@@ -192,6 +192,6 @@ As we can see the set contains several rules:
 - rule:district-member-with-ticket
 - rule:district-member-with-vip
 
-The `rule:base` rule references the two other rules. And is why it's marked as the root.
+The `rule:base` rule references the two other rules. That is why it's marked as the root.
 
 The rules state that if either `rule:district-member-with-ticket` or the `rule:district-member-with-vip` rule can be satisfied, the set will validate.


### PR DESCRIPTION
This PR fixes minor typos in the docs and fixes the condition comparators. @kamescg I didn't format the json snippets because I wasn't sure of your preferences, but we can format all of the snippets to avoid some inconsistencies.